### PR TITLE
Release 3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# Doggo (Flathub)
+This repository holds the Flathub Manifest for Doggo/DogGTK, go [here to view the app source code.](https://codeberg.org/SOrg/Doggo)

--- a/page.codeberg.SOrg.DogGTK.json
+++ b/page.codeberg.SOrg.DogGTK.json
@@ -44,12 +44,12 @@
                 {
                     "type": "git",
                     "url": "https://codeberg.org/SOrg/Doggo.git",
-                    "tag": "3.0",
+                    "tag": "3.1",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "([\\d.]+)$"
                     },
-                    "commit": "a1d2137de0494f498fd4398816ba332cfca70d7c"
+                    "commit": "2235c08c41e913b662371541b184a9d9a2dc4415"
                 }
             ]
         }

--- a/page.codeberg.SOrg.DogGTK.json
+++ b/page.codeberg.SOrg.DogGTK.json
@@ -3,7 +3,7 @@
     "runtime": "org.gnome.Platform",
     "runtime-version": "45",
     "sdk": "org.gnome.Sdk",
-    "command": "dog",
+    "command": "doggo",
     "finish-args": [
         "--share=ipc",
         "--socket=fallback-x11",


### PR DESCRIPTION
Updates tag version and adds README.md to this repository to guide users upstream (I think that is the correct way to say it).